### PR TITLE
fix: better outputs for platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_combined_payload"></a> [combined\_payload](#output\_combined\_payload) | n/a |
+| <a name="output_access_blob"></a> [access\_blob](#output\_access\_blob) | n/a |
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | n/a |
 | <a name="output_table_locations"></a> [table\_locations](#output\_table\_locations) | n/a |
 | <a name="output_wif_audience"></a> [wif\_audience](#output\_wif\_audience) | n/a |

--- a/output.tf
+++ b/output.tf
@@ -1,6 +1,6 @@
 locals {
     project_id            = google_project.billing_export.project_id
-    table_locations       = { for key in var.billing_tables :  key => data.google_bigquery_dataset.table_datasets[key].location }
+    table_locations       = [ for key in var.billing_tables : { table = key, location = data.google_bigquery_dataset.table_datasets[key].location }]
     wif_audience          = "//iam.googleapis.com/projects/${google_project.billing_export.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.stacklet_access.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.stacklet_account.workload_identity_pool_provider_id}"
     wif_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${google_service_account.billing_access.email}:generateAccessToken"
 }
@@ -21,11 +21,11 @@ output "wif_impersonation_url" {
     value = local.wif_impersonation_url
 }
 
-output "combined_payload" {
+output "access_blob" {
     value = base64encode(jsonencode({
-        project_id            = local.project_id,
-        table_locations       = local.table_locations,
-        wif_audience          = local.wif_audience,
-        wif_impersonation_url = local.wif_impersonation_url,
+        projectId           = local.project_id,
+        tableLocations      = local.table_locations,
+        wifAudience         = local.wif_audience,
+        wifImpersonationURL = local.wif_impersonation_url,
     }))
 }


### PR DESCRIPTION
### what

Renames the `combined_payload` output to `access_blob`, and makes its content match the format expected by the non-blob `UpdateGCPCostImportAccessConfigInput`.

### why

Dramatically simplifies validation platform-side.

### testing

Apply from scratch (against a faked-up BQ table of my own) succeeded and generated an access_blob that decoded as expected.

### docs

Nope.
