### PR TITLE
fix: doc and resource name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,12 @@ This repository provides automation for granting Stacklet access to pre-existing
 
 The terraform in this repository allows a single Stacklet-controlled AWS IAM role to execute BigQuery jobs against any number of billing data exports in GCP. Suitable configuration variables will be supplied by Stacklet, and the resulting outputs must be communicated back to Stacklet.
 
-It must be applied by an identity with sufficient privileges to:
-* create a project and associate a billing account id
-* grant `roles/bigquery.dataViewer` on each configured billing export table
-
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+It must be applied by an identity with sufficient privileges to:
+* create a project and associate a billing account id
+* grant `roles/bigquery.dataViewer` on each configured billing export table
 
 ## Providers
 

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "google_iam_workload_identity_pool_provider" "stacklet_account" {
   project                            = google_project.billing_export.project_id
   workload_identity_pool_id          = google_iam_workload_identity_pool.stacklet_access.workload_identity_pool_id
   workload_identity_pool_provider_id = "stacklet-account"
-  display_name                       = "Stacklet FOCUS export"
+  display_name                       = "Stacklet billing queries"
   disabled                           = false
 
   # The default attribute mapping for AWS sets `aws_role` attribute which matches the


### PR DESCRIPTION
### what

* Removes a mention of FOCUS left over from initial exploratory work.
* Puts the requirements to run the terraform in the requirements section.

### why

It's better this way.

### testing

By inspection.

### docs

No.
