### PR TITLE
feat: roundtrip digest (ENG-4725)

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -27,5 +27,6 @@ output "access_blob" {
     tableLocations      = local.table_locations,
     wifAudience         = local.wif_audience,
     wifImpersonationURL = local.wif_impersonation_url,
+    roundtripDigest     = var.roundtrip_digest,
   }))
 }

--- a/vars.tf
+++ b/vars.tf
@@ -50,3 +50,9 @@ variable "stacklet_aws_role_name" {
   type        = string
   description = "AWS IAM role which will use WIF to query billing data (chosen by Stacklet)"
 }
+
+variable "roundtrip_digest" {
+  type        = string
+  default     = null
+  description = "Token used by the Stacklet Platform to detect mismatch between customerConfig and accessConfig"
+}


### PR DESCRIPTION
[ENG-4725](https://stacklet.atlassian.net/browse/ENG-4725)

### what

Accepts a `roundtrip_digest` variable and puts it into the `access_blob` output.

### why

So that the Stacklet Platform can track whether a given customer configuration change has been fully applied.

### testing

Produces sensible `access_blob` output with and without var set, with and without this patch.

### docs

Called out in https://stacklet.atlassian.net/browse/ENG-4732


[ENG-4725]: https://stacklet.atlassian.net/browse/ENG-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ