### PR TITLE
feat: pre-existing project; resource prefix (ENG-4888)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ The terraform in this repository allows a single Stacklet-controlled AWS IAM rol
 ## Requirements
 
 It must be applied by an identity with sufficient privileges to:
-* create a project and associate a billing account id
 * grant `roles/bigquery.dataViewer` on each configured billing export table
+* (if `create_project` is set) create a project and associate a billing account id
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 6.18.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.23.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.12.1 |
 
 ## Modules
 
@@ -36,20 +37,26 @@ No modules.
 | [google_project_service.iamcredentials](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_service) | resource |
 | [google_service_account.billing_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account) | resource |
 | [google_service_account_iam_policy.billing_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_iam) | resource |
+| [time_sleep.stacklet_access_creation_delay](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [google_bigquery_dataset.table_datasets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/bigquery_dataset) | data source |
 | [google_iam_policy.stacklet_role_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
+| [google_project.existing_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_billing_tables"></a> [billing\_tables](#input\_billing\_tables) | Billing export tables in <project\_id>.<dataset\_id>.<table\_id> format. | `list(string)` | n/a | yes |
-| <a name="input_project_billing_account_id"></a> [project\_billing\_account\_id](#input\_project\_billing\_account\_id) | Billing account responsible for any costs incurred | `string` | `null` | no |
-| <a name="input_project_folder_id"></a> [project\_folder\_id](#input\_project\_folder\_id) | Where to create the project (optional, exclusive of project\_org\_id) | `string` | `null` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project to hold all resources | `string` | n/a | yes |
-| <a name="input_project_org_id"></a> [project\_org\_id](#input\_project\_org\_id) | Where to create the project (optional, exclusive of project\_folder\_id) | `string` | `null` | no |
-| <a name="input_resource_labels"></a> [resource\_labels](#input\_resource\_labels) | Labels to apply to the project and applicable resources | `map` | `{}` | no |
-| <a name="input_stacklet_aws_account_id"></a> [stacklet\_aws\_account\_id](#input\_stacklet\_aws\_account\_id) | AWS account which will use WIF to query billing data (chosen by Stacklet) | `string` | n/a | yes |
-| <a name="input_stacklet_aws_role_name"></a> [stacklet\_aws\_role\_name](#input\_stacklet\_aws\_role\_name) | AWS IAM role which will use WIF to query billing data (chosen by Stacklet) | `string` | n/a | yes |
+| <a name="input_billing_tables"></a> [billing\_tables](#input\_billing\_tables) | Billing export tables in '<project\_id>.<dataset\_id>.<table\_id>' format. | `list(string)` | n/a | yes |
+| <a name="input_create_project"></a> [create\_project](#input\_create\_project) | To create resources in a pre-existing project, set this to false.<br/><br/>The pre-existing project must have the 'iamcredentials' and 'bigquery' services enabled. | `bool` | `true` | no |
+| <a name="input_project_billing_account_id"></a> [project\_billing\_account\_id](#input\_project\_billing\_account\_id) | Billing account responsible for any costs incurred. | `string` | `null` | no |
+| <a name="input_project_folder_id"></a> [project\_folder\_id](#input\_project\_folder\_id) | Where to create the project (optional, exclusive of project\_org\_id). | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project to hold all resources. | `string` | n/a | yes |
+| <a name="input_project_org_id"></a> [project\_org\_id](#input\_project\_org\_id) | Where to create the project (optional, exclusive of project\_folder\_id). | `string` | `null` | no |
+| <a name="input_resource_labels"></a> [resource\_labels](#input\_resource\_labels) | Labels to apply to the project and applicable resources. | `map(string)` | `{}` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | If set, prepended to all non-project resource identifiers. | `string` | `""` | no |
+| <a name="input_roundtrip_digest"></a> [roundtrip\_digest](#input\_roundtrip\_digest) | Token used by the Stacklet Platform to detect mismatch between customerConfig and accessConfig. | `string` | `null` | no |
+| <a name="input_stacklet_aws_account_id"></a> [stacklet\_aws\_account\_id](#input\_stacklet\_aws\_account\_id) | AWS account which will use WIF to query billing data (chosen by Stacklet). | `string` | n/a | yes |
+| <a name="input_stacklet_aws_role_name"></a> [stacklet\_aws\_role\_name](#input\_stacklet\_aws\_role\_name) | AWS IAM role which will use WIF to query billing data (chosen by Stacklet). | `string` | n/a | yes |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 
   // Use local.project_id in favour of var.project_id, to ensure dependency ordering.
   project_id     = var.create_project ? google_project.billing_export[0].project_id : var.project_id
-  project_number = var.create_project ? google_project.billing_export[0].number : data.google_project.existing_project[0].number
+  project_number = var.create_project ? google_project.billing_export[0].number : data.google_project.existing[0].number
 
   resource_prefix = var.resource_prefix == "" ? "" : "${var.resource_prefix}-"
 
@@ -51,7 +51,7 @@ resource "google_project_service" "bigquery" {
 
 // Or, the pre-existing project for the resources to live in, with the
 // expectation that the necessary APIs are already enabled out of band.
-data "google_project" "existing_project" {
+data "google_project" "existing" {
   count = local.project_data_count
 
   project_id = var.project_id

--- a/output.tf
+++ b/output.tf
@@ -1,7 +1,6 @@
 locals {
-  project_id            = google_project.billing_export.project_id
   table_locations       = [for key in var.billing_tables : { table = key, location = data.google_bigquery_dataset.table_datasets[key].location }]
-  wif_audience          = "//iam.googleapis.com/projects/${google_project.billing_export.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.stacklet_access.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.stacklet_account.workload_identity_pool_provider_id}"
+  wif_audience          = "//iam.googleapis.com/projects/${local.project_number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.stacklet_access.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.stacklet_account.workload_identity_pool_provider_id}"
   wif_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${google_service_account.billing_access.email}:generateAccessToken"
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -1,58 +1,89 @@
 variable "resource_labels" {
   type        = map(string)
   default     = {}
-  description = "Labels to apply to the project and applicable resources"
+  description = "Labels to apply to the project and applicable resources."
+}
+
+variable "resource_prefix" {
+  type        = string
+  default     = ""
+  description = "If set, prepended to all non-project resource identifiers."
 }
 
 variable "project_id" {
   type        = string
-  description = "ID of project to hold all resources"
+  description = "ID of project to hold all resources."
+}
+
+variable "create_project" {
+  type        = bool
+  default     = true
+  description = <<EOT
+To create resources in a pre-existing project, set this to false.
+
+The pre-existing project must have the 'iamcredentials' and 'bigquery' services enabled.
+EOT
 }
 
 variable "project_org_id" {
   type        = string
   default     = null
-  description = "Where to create the project (optional, exclusive of project_folder_id)"
+  description = "Where to create the project (optional, exclusive of project_folder_id)."
+
+  validation {
+    condition     = (var.project_org_id == null) || (var.create_project)
+    error_message = "project_org_id is only meaningful when this module is responsible for the project."
+  }
 }
 
 variable "project_folder_id" {
   type        = string
   default     = null
-  description = "Where to create the project (optional, exclusive of project_org_id)"
+  description = "Where to create the project (optional, exclusive of project_org_id)."
 
   validation {
     condition     = var.project_org_id == null || var.project_folder_id == null
-    error_message = "project_org_id and project_folder_id are exclusive"
+    error_message = "project_org_id and project_folder_id are exclusive."
+  }
+
+  validation {
+    condition     = var.project_folder_id == null || var.create_project
+    error_message = "project_folder_id is only meaningful when this module is responsible for the project."
   }
 }
 
 variable "project_billing_account_id" {
   type        = string
   default     = null
-  description = "Billing account responsible for any costs incurred"
+  description = "Billing account responsible for any costs incurred."
+
+  validation {
+    condition     = var.project_billing_account_id == null || var.create_project
+    error_message = "project_billing_account_id is only meaningful when this module is responsible for the project."
+  }
 }
 
 variable "billing_tables" {
   type        = list(string)
-  description = "Billing export tables in <project_id>.<dataset_id>.<table_id> format."
+  description = "Billing export tables in '<project_id>.<dataset_id>.<table_id>' format."
   validation {
     condition     = alltrue([for t in var.billing_tables : length(split(".", t)) == 3])
-    error_message = "All tables must be <project_id>.<dataset_id>.<table_id>"
+    error_message = "All tables must be '<project_id>.<dataset_id>.<table_id>'."
   }
 }
 
 variable "stacklet_aws_account_id" {
   type        = string
-  description = "AWS account which will use WIF to query billing data (chosen by Stacklet)"
+  description = "AWS account which will use WIF to query billing data (chosen by Stacklet)."
 }
 
 variable "stacklet_aws_role_name" {
   type        = string
-  description = "AWS IAM role which will use WIF to query billing data (chosen by Stacklet)"
+  description = "AWS IAM role which will use WIF to query billing data (chosen by Stacklet)."
 }
 
 variable "roundtrip_digest" {
   type        = string
   default     = null
-  description = "Token used by the Stacklet Platform to detect mismatch between customerConfig and accessConfig"
+  description = "Token used by the Stacklet Platform to detect mismatch between customerConfig and accessConfig."
 }


### PR DESCRIPTION
[ENG-4888](https://stacklet.atlassian.net/browse/ENG-4888)

### what

* Adds `var.create_project`, which can be set to `false` to use a pre-existing project.
* Adds `var.resource_prefix`, prepended to the names of created resources within the project.

### why

* `create_project` to enable a customer whose processes don't allow for ad-hoc project creation.
* `resource_prefix` to ensure that customers who put these resources into existing projects have a way to avoid name collisions.

### testing

* Updating an existing deployment with old vars and current code makes no changes.
* Fresh deployment which creates a project works as expected.
* Fresh deployment into a pre-existing project works as expected.

### docs

README updated with current vars/resources/providers.


[ENG-4888]: https://stacklet.atlassian.net/browse/ENG-4888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ