### PR TITLE
fix: more prefix space

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ resource "google_iam_workload_identity_pool_provider" "stacklet_account" {
 # Service account, which can be impersonated by `local.stacklet_assumed_role`.
 resource "google_service_account" "billing_access" {
   project      = local.project_id
-  account_id   = "${local.resource_prefix}stacklet-billing-access"
+  account_id   = "${local.resource_prefix}stacklet-access"
   display_name = "Stacklet WIF billing access"
 }
 data "google_iam_policy" "stacklet_role_access" {

--- a/vars.tf
+++ b/vars.tf
@@ -8,6 +8,11 @@ variable "resource_prefix" {
   type        = string
   default     = ""
   description = "If set, prepended to all non-project resource identifiers."
+
+  validation {
+    condition     = length(var.resource_prefix) <= 14
+    error_message = "resource_prefix can be no longer than 14 characters."
+  }
 }
 
 variable "project_id" {


### PR DESCRIPTION
### what

Shortens the non-prefix part of the service account resource name.

### why

Service account names have a maximum length of 30; the original name choice only leaves 6 characters available for a prefix, which this brings up to 14.

### testing

Plans and applies successfully with. 14-character prefix. Rejects 15-character prefix.

### docs

Nothing at this time.
